### PR TITLE
Only apply template for single view

### DIFF
--- a/blank-slate.php
+++ b/blank-slate.php
@@ -122,6 +122,12 @@ class BlankSlatePageTemplater {
 
 		global $post;
 
+		if ( ! is_singular() ) {
+			
+			return $template;
+			
+		}
+		
 		if ( ! isset( $this->templates[ get_post_meta(
 				$post->ID, '_wp_page_template', true
 			) ] )


### PR DESCRIPTION
Prevents the template from being applied during multi-post loops, like search results. Inspired by this issue: https://wordpress.org/support/topic/search-results-80/