### PR TITLE
Showing title for themes that don't support title-tag

### DIFF
--- a/blank-slate-template.php
+++ b/blank-slate-template.php
@@ -2,6 +2,9 @@
 <html <?php language_attributes(); ?>>
 <head>
   <meta charset="<?php bloginfo( 'charset' ); ?>">
+  <?php if ( ! get_theme_support( 'title-tag' ) ): ?>
+    <title><?php wp_title(); ?></title>
+  <?php endif; ?>
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="profile" href="http://gmpg.org/xfn/11">
 


### PR DESCRIPTION
`title-tag` was introduced WordPress 4.1. It changed behavior of WordPress to add the title inside of `wp_head()`. Not all themes support this and instead call `wp_title()` directly. This PR allows Blank Slate to show the title when themes do not support `title-tag`.